### PR TITLE
Add Seed support, Grayscale/Gravity refactor

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,9 +34,9 @@ function buildPathString(pathParts) {
  * - `grayscale` (boolean)
  * - `random` (boolean)
  * - `blur` (boolean)
- * - `gravity` (string, one of "east", "north", "south", "west" or "center")
+ * - `seed` (string)
  *
- * Note: `random` is ignored if `image` is supplied.
+ * Note: `random` and `seed` are ignored if `image` is supplied and `random` is ignored if `seed` is supplied.
  *
  * @param {object} opts The options describing the image.
  * @returns {string} Returns the url to the image.
@@ -53,10 +53,12 @@ function loremPicsum(opts) {
     throw new Error("opts.width must be a number");
   }
 
-  if (opts.grayscale) {
-    path.push("g");
-  }
-
+    // seed - ignored if image id set
+    if (opts.seed && typeof opts.image === 'undefined') {
+      path.push("seed");
+      path.push(opts.seed);
+    }
+  
   path.push(opts.width.toString());
 
   if (opts.height) {
@@ -77,9 +79,9 @@ function loremPicsum(opts) {
   if (opts.blur) {
     query.blur = "";
   }
-
-  if (opts.gravity) {
-    query.gravity = opts.gravity;
+  
+  if (opts.grayscale) {
+    query.grayscale = "";
   }
 
   // return the url

--- a/test/index.js
+++ b/test/index.js
@@ -18,5 +18,5 @@ console.log(loremPicsum({ width: 200, height: 300, image: 0 }));
 // blurred image
 console.log(loremPicsum({ width: 200, height: 300, blur: true }));
 
-// crop gravity
-console.log(loremPicsum({ width: 200, height: 300, gravity: "east" }));
+// seeded image
+console.log(loremPicsum({ width: 200, height: 300, seed: "testSeed"}));


### PR DESCRIPTION
## Seed Option
Support for the `seed` path option has been added. This allows an image to be retrieved randomly, but consistent across seeds.

For example
`https://picsum.photos/seed/testSeed/200/300`  
Will always result in:
![](https://i.picsum.photos/id/1058/200/300.jpg)

**Note: if `image` is supplied, `seed` will be ignored just like the `random` option. If `seed` is supplied, then `random` will be ignored.** 
### Usage Examples
#### Basic Example
```javascript
loremPicsum({ width: 200, height: 300, seed: "testSeed"}) // => https://picsum.photos/seed/testSeed/200/300
```  
![](https://picsum.photos/seed/testSeed/200/300)
#### Grayscale
```javascript
loremPicsum({ width: 200, height: 300, seed: "testSeed", grayscale: true}) // => https://picsum.photos/seed/testSeed/200/300/?grayscale
```  
![](https://picsum.photos/seed/testSeed/200/300/?grayscale)
#### Blur
```javascript
loremPicsum({ width: 200, height: 300, seed: "testSeed", blur: true}) // => https://picsum.photos/seed/testSeed/200/300/?blur
```  
![](https://picsum.photos/seed/testSeed/200/300/?blur)

## Grayscale Refactor
The `grayscale` option has been refactored from a `path` option into a `query` option, to better match the current API:
```
// Before:
// https://picsum.photos/g/200/300

// After:
// https://picsum.photos/200/300/?grayscale
```

## Gravity Refector (removed)
The `gravity` (crop gravity) option has been removed.
This option is no longer mentioned on the official page of the API (see: https://picsum.photos/)
While this option can still be included in the URL, it does not produce different results:
```
https://picsum.photos/200/300/?image=0
```
![](https://picsum.photos/200/300/?image=0)  

```
https://picsum.photos/200/300/?image=0&gravity=east
```
![](https://picsum.photos/200/300/?image=0&gravity=east)